### PR TITLE
BLD: enable ABI3 forward-compatible wheels for CPython

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,13 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.11.2
-
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir dist
+        uses: pypa/cibuildwheel@v2.14.1
+        with:
+          output-dir: dist
 
       - uses: actions/upload-artifact@v3
         with:
@@ -39,12 +36,26 @@ jobs:
       - uses: actions/setup-python@v3
 
       - name: Create source distribution
-        run: python ./setup.py sdist
+        run: pipx run build --sdist
 
       - uses: actions/upload-artifact@v3
         with:
           name: python-package-distributions
           path: ./dist/*.tar.gz
+
+  audit_abi3_wheels:
+    name: Audit ABI3 wheels
+    runs-on: ubuntu-latest
+    needs:
+      - build_wheels
+
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: ./dist/
+      - uses: actions/setup-python@v3
+      - run: pipx run abi3audit dist/*abi3*.whl
 
   publish:
     name: Publish to PyPI
@@ -52,6 +63,7 @@ jobs:
     needs:
       - build_wheels
       - build_sdist
+      - audit_abi3_wheels
 
     steps:
       - uses: actions/download-artifact@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 40.9.0", "wheel"]
+requires = ["setuptools >= 40.9.0"]
 build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,20 @@
 __author__ = "Konstantin Weddige"
+import sysconfig
 from setuptools import setup, Extension
+
+
+MINIMAL_PYTHON_VERSION = major, minor = (3, 6)
+
+# build with Py_LIMITED_API unless in freethreading build (which does not currently
+# support the limited API in py313t)
+USE_PY_LIMITED_API = not sysconfig.get_config_var("Py_GIL_DISABLED")
+define_macros = []
+
+if USE_PY_LIMITED_API:
+    define_macros.append(("Py_LIMITED_API", f"0x{major:02X}{minor:02X}0000"))
+    options = {"bdist_wheel": {"py_limited_api": f"cp{major}{minor}"}}
+else:
+    options = {}
 
 with open("README.rst", "r", encoding="utf-8") as fh:
     long_description = fh.read()
@@ -21,8 +36,11 @@ setup(
             ["src/miniballmodule.cpp"],
             include_dirs=["src"],
             language="c++",
+            define_macros=define_macros,
+            py_limited_api=USE_PY_LIMITED_API,
         ),
     ],
+    python_requires=_get_python_requires(),
     classifiers=[
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Programming Language :: Python",
@@ -31,4 +49,5 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Topic :: Utilities",
     ],
+    options=options,
 )


### PR DESCRIPTION
In preparation for Python 3.12, implement #7 

I was pleasantly surprised to see that _no_ code adaptation was needed, as the `Miniball.cpp` extension is *already* ABI3 (`Py_LIMITED_API`) compatible, so this ends up being a pure infrastructural PR.

I've followed documentation guidelines from cibuildwheel: https://cibuildwheel.readthedocs.io/en/stable/faq/#abi3
